### PR TITLE
Fix the homepage to jQuery Plugins registry

### DIFF
--- a/jquery.once.js
+++ b/jquery.once.js
@@ -1,6 +1,6 @@
 /*!
  * jQuery Once 2.0.0-alpha.8
- * http://plugins.jquery.com/once/
+ * http://npmjs.org/package/jquery-once
  *
  * Dual licensed under the MIT and GPL licenses:
  *   http://www.opensource.org/licenses/mit-license.php

--- a/jquery.once.js
+++ b/jquery.once.js
@@ -1,6 +1,6 @@
 /*!
  * jQuery Once 2.0.0-alpha.8
- * http://github.com/robloach/jquery-once
+ * http://plugins.jquery.com/once/
  *
  * Dual licensed under the MIT and GPL licenses:
  *   http://www.opensource.org/licenses/mit-license.php


### PR DESCRIPTION
The homepage for the project is at https://github.com/RobLoach/jquery-once . Should we switch it to the jQuery Plugins registry over at http://plugins.jquery.com/once/ ?