### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Method | Installation
 [Composer](https://packagist.org/packages/robloach/jquery-once) | `composer require robloach/jquery-once`
 [Bower](http://bower.io/search/?q=jquery-once) | `bower install jquery-once`
 [Component](https://github.com/componentjs/component) | `component install RobLoach/jquery-once`
-[jsDelivr](http://www.jsdelivr.com/#!jquery.once) | `//cdn.jsdelivr.net/jquery.once/2.1.1/jquery.once.min.js`
+[jsDelivr](http://www.jsdelivr.com/#!jquery.once) | `//cdn.jsdelivr.net/npm/jquery-once@2.2.0/jquery.once.min.js`
 [cdnjs](https://cdnjs.com/libraries/jquery-once) | `//cdnjs.cloudflare.com/ajax/libs/jquery-once/2.1.1/jquery.once.js`
 
 ## Usage


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I noticed your readme shows a link with an old version, new versions are [available under different URLs](https://www.jsdelivr.com/package/npm/jquery-once). The correct link is https://cdn.jsdelivr.net/npm/jquery-once@2.2.0/jquery.once.min.js.

Feel free to ping me if you have any questions regarding this change.